### PR TITLE
Systemd and network interface initialization

### DIFF
--- a/deploy/netifyd.service
+++ b/deploy/netifyd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Netify DPI Daemon
-After=syslog.target network.target
+After=syslog.target network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
The netifyd daemon depends on network interfaces being up and ready, so
the systemd netifyd.service needed a tweak.